### PR TITLE
Use folderkey option in _uploadCheck

### DIFF
--- a/mfuploader.js
+++ b/mfuploader.js
@@ -330,6 +330,9 @@
             filename: oFile.name,
             resumable: 'yes'
         };
+        
+        if (this._options.folderkey)
+            oParams.folder_key = this._options.folderkey;
 
         this._apiRequest('check', oParams, {
             load: function(evt) {


### PR DESCRIPTION
With app.upload function, the option folderkey was ignored.